### PR TITLE
@bhoggard: corrects Gris::AuthenticationHelpers env expectation; version bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gris (0.1.3)
+    gris (0.1.4)
       activesupport (~> 4.2, >= 4.2.0)
       dotenv (~> 1.0.2, >= 1.0.2)
       git (~> 1.2, >= 1.2.8)

--- a/lib/gris/generators/templates/scaffold/.env.test.tt
+++ b/lib/gris/generators/templates/scaffold/.env.test.tt
@@ -9,4 +9,4 @@ DATABASE_PASSWORD=''
 DATABASE_HOST=localhost
 DATABASE_NAME=<%= app_name.underscore %>_test
 BASE_URL=http://127.0.0.1:9393
-PERMITTED_TOKENS=["replace-me"]
+PERMITTED_TOKENS=replace-me

--- a/lib/gris/generators/templates/scaffold/.env.tt
+++ b/lib/gris/generators/templates/scaffold/.env.tt
@@ -8,4 +8,4 @@ DATABASE_PASSWORD=''
 DATABASE_HOST=localhost
 DATABASE_NAME=<%= app_name.underscore %>_development
 BASE_URL=http://127.0.0.1:9292
-PERMITTED_TOKENS=["replace-me"]
+PERMITTED_TOKENS=replace-me

--- a/lib/gris/generators/templates/scaffold/spec/support/app_helper.rb.tt
+++ b/lib/gris/generators/templates/scaffold/spec/support/app_helper.rb.tt
@@ -4,7 +4,7 @@ end
 
 shared_context 'with token authorization' do
   before(:each) do
-    permitted_token = ENV['PERMITTED_TOKENS'].dup.gsub!(/[\[\]]/, '').split(/\s*,\s*/).first if ENV['PERMITTED_TOKENS']
+    permitted_token = ENV['PERMITTED_TOKENS'].split(',').first if ENV['PERMITTED_TOKENS']
     header 'Http-Authorization', permitted_token
   end
 end

--- a/lib/gris/grape_extensions/authentication_helpers.rb
+++ b/lib/gris/grape_extensions/authentication_helpers.rb
@@ -15,7 +15,7 @@ module Gris
     end
 
     def permitted_tokens
-      ENV['PERMITTED_TOKENS']
+      ENV['PERMITTED_TOKENS'].split(',')
     end
   end
 end

--- a/lib/gris/version.rb
+++ b/lib/gris/version.rb
@@ -1,5 +1,5 @@
 module Gris
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 
   class Version
     class << self

--- a/spec/grape_extensions/authentication_helpers_spec.rb
+++ b/spec/grape_extensions/authentication_helpers_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Gris::AuthenticationHelpers do
   context 'without permitted token' do
     before(:each) do
-      stub_const 'ENV', 'PERMITTED_TOKENS' => %w(my-token another-token)
+      stub_const 'ENV', 'PERMITTED_TOKENS' => 'my-token,another-token'
       @helper = SpecApiAuthHelper.new
     end
 
@@ -23,11 +23,27 @@ describe Gris::AuthenticationHelpers do
           expect(@helper.token_authentication!).to be_nil
         end
       end
+      context 'with blank params token' do
+        it 'returns a 401 Forbidden error' do
+          allow(@helper).to receive(:params).and_return(token: '')
+          allow(@helper).to receive_message_chain(:request, :headers).and_return('Http-Authorization' => nil)
+          @helper.token_authentication!
+          expect(@helper.message).to eq(message: 'Forbidden', status: 401)
+        end
+      end
       context 'with included request header token' do
         it 'returns nil' do
           allow(@helper).to receive(:params).and_return(token: nil)
           allow(@helper).to receive_message_chain(:request, :headers).and_return('Http-Authorization' => 'my-token')
           expect(@helper.token_authentication!).to be_nil
+        end
+      end
+      context 'with blank header token' do
+        it 'returns a 401 Forbidden error' do
+          allow(@helper).to receive(:params).and_return(token: nil)
+          allow(@helper).to receive_message_chain(:request, :headers).and_return('Http-Authorization' => '')
+          @helper.token_authentication!
+          expect(@helper.message).to eq(message: 'Forbidden', status: 401)
         end
       end
     end


### PR DESCRIPTION
This was a bummer! My mistake here was expecting that the `PERMITTED_TOKENS` env variable would be an array. This changes the expectation. And we'll now split the var to permit an array of tokens.

Still just a short-term patch for this meager authentication strategy.